### PR TITLE
Fix: cast to integer on sanitised integer values only

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,8 +57,9 @@ class puppet_run_scheduler (
   $splaylimit_mins = puppet_run_scheduler::minutes($splaylimit)
 
   $splay_mins = fqdn_rand($splaylimit_mins, 'puppet_run_scheduler')
-  $input_start_hour = Integer($start_time[0,2])
-  $input_start_min  = Integer($start_time[3,2])
+  $start_time_array = split($start_time, ':')
+  $input_start_hour = Integer(regsubst($start_time_array[0], '^0(\d)', '\1'))
+  $input_start_min  = Integer(regsubst($start_time_array[1], '^0(\d)', '\1'))
 
   $splayed_start_epoch_mins = $input_start_hour * 60 + $input_start_min + $splay_mins
   $first_start_epoch_mins   = $splayed_start_epoch_mins % $interval_mins


### PR DESCRIPTION
## Initial situation

Set up `$run_interval` and `$start_time`. The latter consists of a string that looks like "00:xx", xx being derived from `fqdn_rand($run_interval)`, adding a leading zero if the value is less than 10 to satisfy puppet_run_scheduler's input.

## Expected behaviour

Set up the entries in cron or Task Scheduler accordingly. Meaning calling the class with e.g.:
```
# Implying that fqdn_rand($run_interval) gave us an Integer of 8 which we converted to "00:08" to satisfy the input:
class { 'puppet_run_scheduler':
  ensure       => present,
  run_interval => "${run_interval}m",
  start_time   => '00:08',
}
```

## Issue

Cast to integer fails on minutes when $start_time has leading zeroes and any other value than "xx:00". E.g. a value of "00:08" will lead to an error message like:  
`Evaluation Error: Error while evaluating a Function Call, invalid value for Integer(): "08"`

## Workaround

Set up a value greater than or equal 10. With the standard run interval of 30 minutes it's as easy as:

```
$run_interval = 30
$run_minute = fqdn_rand($run_interval) + $run_interval
$start_time = "00:${run_minute}"
# or something similar
```

Other run intervals may require more math, though.

# Solution

## What we do

Since $start_time is formalised through the pattern definition in the class parameters:
1. Split the input start time at the colon
2. Use the array members as input, remove any leading zero
3. Continue to cast to integer

## Paradigm

Right now, this is about fixing the leading zero issue one may face, not touching the start time to be expected as "xx:yy". We do not refactor (yet?).